### PR TITLE
[Fix] 사인 시작 직후 제출 시 종이 상태가 반영되지 않는 오류 수정

### DIFF
--- a/Assets/Resources/2_SignGame/Animations/Anim_RightHand/RightHand_Sign.anim
+++ b/Assets/Resources/2_SignGame/Animations/Anim_RightHand/RightHand_Sign.anim
@@ -112,7 +112,7 @@ AnimationClip:
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
   m_Events:
-  - time: 0.06666667
+  - time: 0
     functionName: SpawnSignLine
     data: 
     objectReferenceParameter: {fileID: 0}

--- a/Assets/Resources/2_SignGame/Animations/Anim_SignLine/SignLIne_Drawing.anim
+++ b/Assets/Resources/2_SignGame/Animations/Anim_SignLine/SignLIne_Drawing.anim
@@ -20,33 +20,33 @@ AnimationClip:
   m_PPtrCurves:
   - serializedVersion: 2
     curve:
-    - time: 0
-      value: {fileID: 21300000, guid: afbb803b6798c4b41a002ff55941b5a0, type: 3}
     - time: 0.06666667
-      value: {fileID: 21300000, guid: 94464752a659d41c3a2842236afa106a, type: 3}
+      value: {fileID: 21300000, guid: afbb803b6798c4b41a002ff55941b5a0, type: 3}
     - time: 0.13333334
-      value: {fileID: 21300000, guid: a6fcc374ecf3b4271a3f0994d5a328b4, type: 3}
+      value: {fileID: 21300000, guid: 94464752a659d41c3a2842236afa106a, type: 3}
     - time: 0.2
-      value: {fileID: 21300000, guid: d3dac2f492783458f8a7ceab9dc18a9e, type: 3}
+      value: {fileID: 21300000, guid: a6fcc374ecf3b4271a3f0994d5a328b4, type: 3}
     - time: 0.26666668
-      value: {fileID: 21300000, guid: df43827c3b9fb431a92d111db5dffbb0, type: 3}
+      value: {fileID: 21300000, guid: d3dac2f492783458f8a7ceab9dc18a9e, type: 3}
     - time: 0.33333334
-      value: {fileID: 21300000, guid: 7a231b15afa93480c9081a0f7f0210fd, type: 3}
+      value: {fileID: 21300000, guid: df43827c3b9fb431a92d111db5dffbb0, type: 3}
     - time: 0.4
-      value: {fileID: 21300000, guid: a39e9c7b5f7f747ebbab160c4b7fd8bc, type: 3}
+      value: {fileID: 21300000, guid: 7a231b15afa93480c9081a0f7f0210fd, type: 3}
     - time: 0.46666667
-      value: {fileID: 21300000, guid: 3cc8f4b87e1a8407285b222cb087f09a, type: 3}
+      value: {fileID: 21300000, guid: a39e9c7b5f7f747ebbab160c4b7fd8bc, type: 3}
     - time: 0.53333336
-      value: {fileID: 21300000, guid: e5e5dfce4e95a46d485a0fbe598d9cb3, type: 3}
+      value: {fileID: 21300000, guid: 3cc8f4b87e1a8407285b222cb087f09a, type: 3}
     - time: 0.6
-      value: {fileID: 21300000, guid: e1b89b182608c4653a339e7af495addd, type: 3}
+      value: {fileID: 21300000, guid: e5e5dfce4e95a46d485a0fbe598d9cb3, type: 3}
     - time: 0.6666667
-      value: {fileID: 21300000, guid: a1a831ce89d8b437dadcabbb3fb51295, type: 3}
+      value: {fileID: 21300000, guid: e1b89b182608c4653a339e7af495addd, type: 3}
     - time: 0.73333335
-      value: {fileID: 21300000, guid: c4979a0150c5b4a529772710aad983cb, type: 3}
+      value: {fileID: 21300000, guid: a1a831ce89d8b437dadcabbb3fb51295, type: 3}
     - time: 0.8
-      value: {fileID: 21300000, guid: d16e99cbe70de4a629678bec75867744, type: 3}
+      value: {fileID: 21300000, guid: c4979a0150c5b4a529772710aad983cb, type: 3}
     - time: 0.8666667
+      value: {fileID: 21300000, guid: d16e99cbe70de4a629678bec75867744, type: 3}
+    - time: 0.93333334
       value: {fileID: 21300000, guid: cef99787cf4514603b41bfe88413821f, type: 3}
     attribute: m_Sprite
     path: 
@@ -89,7 +89,7 @@ AnimationClip:
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.93333334
+    m_StopTime: 1
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Scene/SignGameScene.unity
+++ b/Assets/Scene/SignGameScene.unity
@@ -265,6 +265,71 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   leftHand: {fileID: 767295183}
   rightHand: {fileID: 1247764299}
+--- !u!1001 &217400390
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1021016425576204864, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
+      propertyPath: m_Name
+      value: SignLine
+      objectReference: {fileID: 0}
+    - target: {fileID: 1021016425576204864, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4400200818129508129, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4400200818129508129, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4400200818129508129, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.48
+      objectReference: {fileID: 0}
+    - target: {fileID: 4400200818129508129, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4400200818129508129, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4400200818129508129, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4400200818129508129, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4400200818129508129, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4400200818129508129, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4400200818129508129, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4400200818129508129, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 18ba8d7b4dab24dd1abcb31c2dc9bf95, type: 3}
 --- !u!1 &255297848
 GameObject:
   m_ObjectHideFlags: 0
@@ -1100,7 +1165,6 @@ MonoBehaviour:
   signPlayerAction: {fileID: 127698210}
   paperSpawnPosition: {fileID: 576217831}
   currentPaper: {fileID: 105860758}
-  isSuccess: 0
 --- !u!114 &1281619933
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
- 사인하기 동작이 시작되자마자(오른손 애니메이션) 종이를 제출할 경우, 종이 상태 및 애니메이션이 찢어진 상태로 변경되지 않는 오류 발생
- 원인: 사인 생성 및 상태 변경이 RightHand_Sign 애니메이션의 두 번째 프레임에 처리되어, 첫 프레임에 제출하면 종이 상태가 아직 반영되지 않음
- 해결: 사인 생성 이벤트를 애니메이션의 첫 프레임으로 이동시켜 판정이 정확히 반영되도록 수정
- 자연스러움을 유지하기 위해, 사인(SignLine) 생성 후 실행되는 애니메이션의 시작 타이밍을 1프레임 뒤로 지연